### PR TITLE
Add -r (--array) to squeue_output()

### DIFF
--- a/slurm_usage.py
+++ b/slurm_usage.py
@@ -12,7 +12,7 @@ from rich.table import Table
 
 
 def squeue_output():
-    cmd = [f"squeue -o '%u/%t/%D/%P'"]
+    cmd = [f"squeue -ro '%u/%t/%D/%P'"]
     return subprocess.getoutput(cmd).split("\n")[1:]
 
 


### PR DESCRIPTION
One character commit 😉 Pending job array elements are combined on one line of output with the array index values printed in regular expression format when the flag `-r` or `--array` is not passed to the squeue command.

For example, launching 768 jobs using two different slurm instances outputs a cell: `PD=2 / R=240` next to my User entry as opposed to `PD=528 / R=240`.