### PR TITLE
fix: add COLUMNS and _TYPER_FORCE_DISABLE_TERMINAL for consistent output

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -39,7 +39,9 @@ jobs:
         env:
           TERM: dumb
           NO_COLOR: 1
-          TERMINAL_WIDTH: 90
+          COLUMNS: 90  # POSIX terminal width for Rich
+          TERMINAL_WIDTH: 90  # Typer MAX_WIDTH for help panels
+          _TYPER_FORCE_DISABLE_TERMINAL: 1  # Prevent Typer forcing terminal mode in CI
         run: |
           # Set environment variable to use mock data for tests
           export SLURM_USE_MOCK_DATA=1


### PR DESCRIPTION
## Summary
Fix markdown-code-runner producing inconsistent terminal widths between CI and local.

- Add `COLUMNS: 90` - POSIX terminal width for Rich console
- Add `_TYPER_FORCE_DISABLE_TERMINAL: 1` - Prevents Typer from forcing terminal mode in CI

Without `_TYPER_FORCE_DISABLE_TERMINAL`, Typer detects `GITHUB_ACTIONS` and forces terminal mode, which combined with `TERM=dumb` causes Rich to ignore `COLUMNS` and fall back to 80 chars.

See: https://github.com/basnijholt/agent-cli/pull/253 and https://github.com/basnijholt/agent-cli/pull/255

## Test plan
- [x] CI passes with no README changes pushed