### PR TITLE
style: redesign logo with circular gauge

### DIFF
--- a/docs/assets/logo-icon.svg
+++ b/docs/assets/logo-icon.svg
@@ -1,38 +1,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
   <defs>
-    <linearGradient id="serverGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+    <linearGradient id="ringGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#3B82F6"/>
       <stop offset="100%" style="stop-color:#1D4ED8"/>
     </linearGradient>
-    <linearGradient id="barGradient1" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="100%" style="stop-color:#34D399"/>
-    </linearGradient>
-    <linearGradient id="barGradient2" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#F59E0B"/>
-      <stop offset="100%" style="stop-color:#FBBF24"/>
-    </linearGradient>
-    <linearGradient id="barGradient3" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#EF4444"/>
-      <stop offset="100%" style="stop-color:#F87171"/>
-    </linearGradient>
   </defs>
 
-  <!-- Server rack base -->
-  <rect x="10" y="10" width="80" height="80" rx="8" fill="url(#serverGradient)"/>
+  <!-- Outer ring (background) -->
+  <circle cx="50" cy="50" r="42" fill="none" stroke="#E5E7EB" stroke-width="10"/>
 
-  <!-- Server slots (node lines) -->
-  <rect x="18" y="18" width="64" height="10" rx="3" fill="#1E3A5F" opacity="0.5"/>
-  <rect x="18" y="32" width="64" height="10" rx="3" fill="#1E3A5F" opacity="0.5"/>
-  <rect x="18" y="46" width="64" height="10" rx="3" fill="#1E3A5F" opacity="0.5"/>
+  <!-- Usage arc (showing ~70% efficiency) -->
+  <circle cx="50" cy="50" r="42" fill="none" stroke="url(#ringGradient)" stroke-width="10"
+          stroke-dasharray="185 264" stroke-dashoffset="-40" stroke-linecap="round"/>
 
-  <!-- Usage bars (bar chart overlay) -->
-  <rect x="25" y="40" width="14" height="42" rx="3" fill="url(#barGradient1)"/>
-  <rect x="43" y="52" width="14" height="30" rx="3" fill="url(#barGradient2)"/>
-  <rect x="61" y="32" width="14" height="50" rx="3" fill="url(#barGradient3)"/>
+  <!-- Center display -->
+  <circle cx="50" cy="50" r="28" fill="#F8FAFC"/>
 
-  <!-- Status LEDs -->
-  <circle cx="24" cy="23" r="3" fill="#34D399"/>
-  <circle cx="24" cy="37" r="3" fill="#34D399"/>
-  <circle cx="24" cy="51" r="3" fill="#FBBF24"/>
+  <!-- Bar chart in center -->
+  <rect x="30" y="52" width="10" height="22" rx="2" fill="#10B981"/>
+  <rect x="45" y="38" width="10" height="36" rx="2" fill="#3B82F6"/>
+  <rect x="60" y="46" width="10" height="28" rx="2" fill="#8B5CF6"/>
 </svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,40 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120" width="100" height="120">
   <defs>
-    <linearGradient id="serverGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+    <linearGradient id="gaugeGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#10B981"/>
+      <stop offset="50%" style="stop-color:#F59E0B"/>
+      <stop offset="100%" style="stop-color:#EF4444"/>
+    </linearGradient>
+    <linearGradient id="ringGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#3B82F6"/>
       <stop offset="100%" style="stop-color:#1D4ED8"/>
     </linearGradient>
-    <linearGradient id="barGradient1" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="100%" style="stop-color:#34D399"/>
-    </linearGradient>
-    <linearGradient id="barGradient2" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#F59E0B"/>
-      <stop offset="100%" style="stop-color:#FBBF24"/>
-    </linearGradient>
-    <linearGradient id="barGradient3" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#EF4444"/>
-      <stop offset="100%" style="stop-color:#F87171"/>
-    </linearGradient>
   </defs>
 
-  <!-- Server rack base -->
-  <rect x="15" y="20" width="70" height="70" rx="6" fill="url(#serverGradient)"/>
+  <!-- Outer ring (background) -->
+  <circle cx="50" cy="50" r="38" fill="none" stroke="#E5E7EB" stroke-width="8"/>
 
-  <!-- Server slots (node lines) -->
-  <rect x="22" y="28" width="56" height="8" rx="2" fill="#1E3A5F" opacity="0.5"/>
-  <rect x="22" y="40" width="56" height="8" rx="2" fill="#1E3A5F" opacity="0.5"/>
-  <rect x="22" y="52" width="56" height="8" rx="2" fill="#1E3A5F" opacity="0.5"/>
+  <!-- Usage arc (showing ~70% efficiency) -->
+  <circle cx="50" cy="50" r="38" fill="none" stroke="url(#ringGradient)" stroke-width="8"
+          stroke-dasharray="168 240" stroke-dashoffset="-36" stroke-linecap="round"/>
 
-  <!-- Usage bars (bar chart overlay) -->
-  <rect x="28" y="45" width="10" height="35" rx="2" fill="url(#barGradient1)"/>
-  <rect x="45" y="55" width="10" height="25" rx="2" fill="url(#barGradient2)"/>
-  <rect x="62" y="38" width="10" height="42" rx="2" fill="url(#barGradient3)"/>
+  <!-- Center display -->
+  <circle cx="50" cy="50" r="26" fill="#F8FAFC"/>
 
-  <!-- Status LEDs -->
-  <circle cx="26" cy="32" r="2" fill="#34D399"/>
-  <circle cx="26" cy="44" r="2" fill="#34D399"/>
-  <circle cx="26" cy="56" r="2" fill="#FBBF24"/>
+  <!-- Bar chart in center -->
+  <rect x="32" y="52" width="8" height="18" rx="2" fill="#10B981"/>
+  <rect x="46" y="42" width="8" height="28" rx="2" fill="#3B82F6"/>
+  <rect x="60" y="48" width="8" height="22" rx="2" fill="#8B5CF6"/>
+
+  <!-- Percentage text -->
+  <text x="50" y="38" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="700" fill="#1E40AF">70%</text>
 
   <!-- Text "slurm-usage" -->
   <text x="50" y="110" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#3B82F6">slurm-usage</text>


### PR DESCRIPTION
## Summary

Redesign the logo to be cleaner and more intuitive:

- **Circular progress ring** showing ~70% efficiency (blue gradient)
- **Clean white center** with three non-overlapping bar charts
- **Percentage display** (70%) above the bars
- Removed confusing overlapping server slots and bars

The ring represents overall usage/efficiency, and the bars inside show different resource metrics.

## Test plan

- [ ] View SVG renders correctly in browser
- [ ] Logo displays properly in README
- [ ] Icon version works for favicon/header