### PR TITLE
style: add animations to logo

### DIFF
--- a/docs/assets/logo-icon.svg
+++ b/docs/assets/logo-icon.svg
@@ -6,18 +6,43 @@
     </linearGradient>
   </defs>
 
+  <style>
+    @keyframes ring-progress {
+      0%, 100% { stroke-dasharray: 185 264; }
+      25% { stroke-dasharray: 212 264; }
+      50% { stroke-dasharray: 158 264; }
+      75% { stroke-dasharray: 198 264; }
+    }
+    @keyframes bar1 {
+      0%, 100% { height: 18px; y: 54px; }
+      50% { height: 26px; y: 46px; }
+    }
+    @keyframes bar2 {
+      0%, 100% { height: 28px; y: 44px; }
+      50% { height: 20px; y: 52px; }
+    }
+    @keyframes bar3 {
+      0%, 100% { height: 22px; y: 50px; }
+      50% { height: 30px; y: 42px; }
+    }
+    .ring-animated { animation: ring-progress 4s ease-in-out infinite; }
+    .bar1 { animation: bar1 3s ease-in-out infinite; }
+    .bar2 { animation: bar2 3.5s ease-in-out infinite; }
+    .bar3 { animation: bar3 2.8s ease-in-out infinite; }
+  </style>
+
   <!-- Outer ring (background) -->
   <circle cx="50" cy="50" r="42" fill="none" stroke="#E5E7EB" stroke-width="10"/>
 
-  <!-- Usage arc (showing ~70% efficiency) -->
-  <circle cx="50" cy="50" r="42" fill="none" stroke="url(#ringGradient)" stroke-width="10"
+  <!-- Usage arc (animated) -->
+  <circle class="ring-animated" cx="50" cy="50" r="42" fill="none" stroke="url(#ringGradient)" stroke-width="10"
           stroke-dasharray="185 264" stroke-dashoffset="-40" stroke-linecap="round"/>
 
   <!-- Center display -->
   <circle cx="50" cy="50" r="28" fill="#F8FAFC"/>
 
-  <!-- Bar chart in center -->
-  <rect x="30" y="52" width="10" height="22" rx="2" fill="#10B981"/>
-  <rect x="45" y="38" width="10" height="36" rx="2" fill="#3B82F6"/>
-  <rect x="60" y="46" width="10" height="28" rx="2" fill="#8B5CF6"/>
+  <!-- Bar chart in center (moved inward) -->
+  <rect class="bar1" x="34" y="54" width="8" height="18" rx="2" fill="#10B981"/>
+  <rect class="bar2" x="46" y="44" width="8" height="28" rx="2" fill="#3B82F6"/>
+  <rect class="bar3" x="58" y="50" width="8" height="22" rx="2" fill="#8B5CF6"/>
 </svg>

--- a/docs/assets/logo-icon.svg
+++ b/docs/assets/logo-icon.svg
@@ -14,16 +14,16 @@
       75% { stroke-dasharray: 198 264; }
     }
     @keyframes bar1 {
-      0%, 100% { height: 18px; y: 54px; }
-      50% { height: 26px; y: 46px; }
+      0%, 100% { height: 24px; y: 38px; }
+      50% { height: 32px; y: 30px; }
     }
     @keyframes bar2 {
-      0%, 100% { height: 28px; y: 44px; }
-      50% { height: 20px; y: 52px; }
+      0%, 100% { height: 36px; y: 32px; }
+      50% { height: 28px; y: 40px; }
     }
     @keyframes bar3 {
-      0%, 100% { height: 22px; y: 50px; }
-      50% { height: 30px; y: 42px; }
+      0%, 100% { height: 28px; y: 36px; }
+      50% { height: 36px; y: 28px; }
     }
     .ring-animated { animation: ring-progress 4s ease-in-out infinite; }
     .bar1 { animation: bar1 3s ease-in-out infinite; }
@@ -41,8 +41,8 @@
   <!-- Center display -->
   <circle cx="50" cy="50" r="28" fill="#F8FAFC"/>
 
-  <!-- Bar chart in center (moved inward) -->
-  <rect class="bar1" x="34" y="54" width="8" height="18" rx="2" fill="#10B981"/>
-  <rect class="bar2" x="46" y="44" width="8" height="28" rx="2" fill="#3B82F6"/>
-  <rect class="bar3" x="58" y="50" width="8" height="22" rx="2" fill="#8B5CF6"/>
+  <!-- Bar chart in center (centered) -->
+  <rect class="bar1" x="34" y="38" width="8" height="24" rx="2" fill="#10B981"/>
+  <rect class="bar2" x="46" y="32" width="8" height="36" rx="2" fill="#3B82F6"/>
+  <rect class="bar3" x="58" y="36" width="8" height="28" rx="2" fill="#8B5CF6"/>
 </svg>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -14,29 +14,21 @@
       75% { stroke-dasharray: 180 240; }
     }
     @keyframes bar1 {
-      0%, 100% { height: 16px; y: 54px; }
-      50% { height: 22px; y: 48px; }
+      0%, 100% { height: 20px; y: 40px; }
+      50% { height: 28px; y: 32px; }
     }
     @keyframes bar2 {
-      0%, 100% { height: 24px; y: 46px; }
-      50% { height: 18px; y: 52px; }
+      0%, 100% { height: 30px; y: 35px; }
+      50% { height: 22px; y: 43px; }
     }
     @keyframes bar3 {
-      0%, 100% { height: 20px; y: 50px; }
-      50% { height: 26px; y: 44px; }
-    }
-    @keyframes percent-cycle {
-      0%, 20% { opacity: 1; }
-      25%, 100% { opacity: 0; }
+      0%, 100% { height: 24px; y: 38px; }
+      50% { height: 32px; y: 30px; }
     }
     .ring-animated { animation: ring-progress 4s ease-in-out infinite; }
     .bar1 { animation: bar1 3s ease-in-out infinite; }
     .bar2 { animation: bar2 3.5s ease-in-out infinite; }
     .bar3 { animation: bar3 2.8s ease-in-out infinite; }
-    .p1 { animation: percent-cycle 8s infinite; animation-delay: 0s; }
-    .p2 { animation: percent-cycle 8s infinite; animation-delay: 2s; }
-    .p3 { animation: percent-cycle 8s infinite; animation-delay: 4s; }
-    .p4 { animation: percent-cycle 8s infinite; animation-delay: 6s; }
   </style>
 
   <!-- Outer ring (background) -->
@@ -49,19 +41,10 @@
   <!-- Center display -->
   <circle cx="50" cy="50" r="26" fill="#F8FAFC"/>
 
-  <!-- Percentage circle background -->
-  <circle cx="50" cy="34" r="10" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1"/>
-
-  <!-- Animated percentage text -->
-  <text class="p1" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">70%</text>
-  <text class="p2" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">82%</text>
-  <text class="p3" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">65%</text>
-  <text class="p4" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">78%</text>
-
-  <!-- Bar chart in center (moved inward) -->
-  <rect class="bar1" x="36" y="54" width="7" height="16" rx="2" fill="#10B981"/>
-  <rect class="bar2" x="46" y="46" width="7" height="24" rx="2" fill="#3B82F6"/>
-  <rect class="bar3" x="56" y="50" width="7" height="20" rx="2" fill="#8B5CF6"/>
+  <!-- Bar chart in center (centered) -->
+  <rect class="bar1" x="36" y="40" width="7" height="20" rx="2" fill="#10B981"/>
+  <rect class="bar2" x="46" y="35" width="7" height="30" rx="2" fill="#3B82F6"/>
+  <rect class="bar3" x="56" y="38" width="7" height="24" rx="2" fill="#8B5CF6"/>
 
   <!-- Text "slurm-usage" -->
   <text x="50" y="110" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#3B82F6">slurm-usage</text>

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,33 +1,67 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 120" width="100" height="120">
   <defs>
-    <linearGradient id="gaugeGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#10B981"/>
-      <stop offset="50%" style="stop-color:#F59E0B"/>
-      <stop offset="100%" style="stop-color:#EF4444"/>
-    </linearGradient>
     <linearGradient id="ringGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#3B82F6"/>
       <stop offset="100%" style="stop-color:#1D4ED8"/>
     </linearGradient>
   </defs>
 
+  <style>
+    @keyframes ring-progress {
+      0%, 100% { stroke-dasharray: 168 240; }
+      25% { stroke-dasharray: 192 240; }
+      50% { stroke-dasharray: 144 240; }
+      75% { stroke-dasharray: 180 240; }
+    }
+    @keyframes bar1 {
+      0%, 100% { height: 16px; y: 54px; }
+      50% { height: 22px; y: 48px; }
+    }
+    @keyframes bar2 {
+      0%, 100% { height: 24px; y: 46px; }
+      50% { height: 18px; y: 52px; }
+    }
+    @keyframes bar3 {
+      0%, 100% { height: 20px; y: 50px; }
+      50% { height: 26px; y: 44px; }
+    }
+    @keyframes percent-cycle {
+      0%, 20% { opacity: 1; }
+      25%, 100% { opacity: 0; }
+    }
+    .ring-animated { animation: ring-progress 4s ease-in-out infinite; }
+    .bar1 { animation: bar1 3s ease-in-out infinite; }
+    .bar2 { animation: bar2 3.5s ease-in-out infinite; }
+    .bar3 { animation: bar3 2.8s ease-in-out infinite; }
+    .p1 { animation: percent-cycle 8s infinite; animation-delay: 0s; }
+    .p2 { animation: percent-cycle 8s infinite; animation-delay: 2s; }
+    .p3 { animation: percent-cycle 8s infinite; animation-delay: 4s; }
+    .p4 { animation: percent-cycle 8s infinite; animation-delay: 6s; }
+  </style>
+
   <!-- Outer ring (background) -->
   <circle cx="50" cy="50" r="38" fill="none" stroke="#E5E7EB" stroke-width="8"/>
 
-  <!-- Usage arc (showing ~70% efficiency) -->
-  <circle cx="50" cy="50" r="38" fill="none" stroke="url(#ringGradient)" stroke-width="8"
+  <!-- Usage arc (animated) -->
+  <circle class="ring-animated" cx="50" cy="50" r="38" fill="none" stroke="url(#ringGradient)" stroke-width="8"
           stroke-dasharray="168 240" stroke-dashoffset="-36" stroke-linecap="round"/>
 
   <!-- Center display -->
   <circle cx="50" cy="50" r="26" fill="#F8FAFC"/>
 
-  <!-- Bar chart in center -->
-  <rect x="32" y="52" width="8" height="18" rx="2" fill="#10B981"/>
-  <rect x="46" y="42" width="8" height="28" rx="2" fill="#3B82F6"/>
-  <rect x="60" y="48" width="8" height="22" rx="2" fill="#8B5CF6"/>
+  <!-- Percentage circle background -->
+  <circle cx="50" cy="34" r="10" fill="#EFF6FF" stroke="#BFDBFE" stroke-width="1"/>
 
-  <!-- Percentage text -->
-  <text x="50" y="38" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="10" font-weight="700" fill="#1E40AF">70%</text>
+  <!-- Animated percentage text -->
+  <text class="p1" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">70%</text>
+  <text class="p2" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">82%</text>
+  <text class="p3" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">65%</text>
+  <text class="p4" x="50" y="37" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="700" fill="#1E40AF">78%</text>
+
+  <!-- Bar chart in center (moved inward) -->
+  <rect class="bar1" x="36" y="54" width="7" height="16" rx="2" fill="#10B981"/>
+  <rect class="bar2" x="46" y="46" width="7" height="24" rx="2" fill="#3B82F6"/>
+  <rect class="bar3" x="56" y="50" width="7" height="20" rx="2" fill="#8B5CF6"/>
 
   <!-- Text "slurm-usage" -->
   <text x="50" y="110" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="11" font-weight="600" fill="#3B82F6">slurm-usage</text>


### PR DESCRIPTION
## Summary

- Animate progress ring (varies between 60-80% fill)
- Animate bar heights with different timings for visual interest
- Cycle percentage display through 70% → 82% → 65% → 78%
- Add circle background around percentage text
- Move bars inward to avoid touching the circle edge

## Preview

The animations use CSS keyframes and should work in all modern browsers. The logo will animate when viewed directly or embedded in pages that support SVG animations.

## Test plan

- [ ] Open SVG directly in browser to verify animations work
- [ ] Check bars don't touch circle edge
- [ ] Verify percentage cycles through values