### PR TITLE
feat: add Plausible analytics to docs site

### DIFF
--- a/docs/overrides/partials/integrations/analytics.html
+++ b/docs/overrides/partials/integrations/analytics.html
@@ -1,0 +1,6 @@
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.nijho.lt/js/pa-mdmmnfxb0ujcJMqliT7Xz.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>

--- a/zensical.toml
+++ b/zensical.toml
@@ -24,6 +24,7 @@ nav = [
 [project.theme]
 logo = "assets/logo-icon.svg"
 language = "en"
+custom_dir = "docs/overrides"
 
 features = [
     "announce.dismiss",
@@ -76,6 +77,9 @@ repo = "lucide/github"
 
 [project.extra]
 generator = false
+
+[project.extra.analytics]
+provider = "custom"
 
 [[project.extra.social]]
 icon = "fontawesome/brands/github"

--- a/zensical.toml
+++ b/zensical.toml
@@ -77,9 +77,6 @@ repo = "lucide/github"
 [project.extra]
 generator = false
 
-[project.extra.analytics]
-provider = "custom"
-
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/basnijholt/slurm-usage"


### PR DESCRIPTION
## Summary
- Adds privacy-friendly Plausible analytics to the documentation site
- Creates `docs/overrides/partials/integrations/analytics.html` with the Plausible tracking script
- Configures custom override directory in zensical.toml

## Test plan
- [ ] Verify docs build succeeds
- [ ] Verify site is accessible at https://slurm-usage.nijho.lt/
- [ ] Verify analytics are tracked in Plausible dashboard